### PR TITLE
Don't create an empty config file if it wasn't there before.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,6 @@
 use std::path::PathBuf;
+#[allow(unused)]
+use serde::de::value::Error;
 use thiserror::Error;
 use crate::ConfigFormat;
 
@@ -70,6 +72,17 @@ pub enum ConfigError {
 	#[error(transparent)]
 	UnknownFormat(UnknownFormatError)
 }
+impl From<std::io::Error> for ConfigError {
+	fn from(item: std::io::Error) -> Self {
+		ConfigError::IoError(item) 
+	}
+}
+
+impl From<DataParseError> for ConfigError {
+	fn from(item: DataParseError) -> Self {
+		ConfigError::DataParseError(item) 
+	}
+}
 
 #[derive(Error, Debug)]
 pub enum ConfigSaveError {
@@ -83,4 +96,11 @@ pub enum ConfigSaveError {
 	#[error("{}", .0)]
 	SerializationError(String)
 }
+
+impl From<std::io::Error> for ConfigSaveError {
+	fn from(item: std::io::Error) -> Self {
+		ConfigSaveError::IoError(item) 
+	}
+}
+
 


### PR DESCRIPTION
Attempts to fix #1 by removing the code that creates a config file if it wasn't initially there.
I see there is code that's supposed to write a well-formed config file in this case, but it's not working for reasons I didn't investigate.

I actually think it's better to not try to write a config file in this case.  The app shouldn't be modifying the filesystem by default.

Also added `impl From<>` for a couple of error structs so I could use `?` in a few places.  But I think crate `thiserror` is worth a look in the future.  It does that, and more, automatically.

Sorry, this is a messy PR -- lots of opinionated coding style lints automagically applied by VS Code...